### PR TITLE
Support dynamic scrape targets

### DIFF
--- a/vmagent/configs/prometheus.yml.tmpl
+++ b/vmagent/configs/prometheus.yml.tmpl
@@ -5,3 +5,5 @@ scrape_configs:
   - job_name: {{ env "VMAGENT_JOB" }}
     static_configs:
       - targets: ['node-exporter:9100']
+scrape_config_files:
+- scrape/*.yml

--- a/vmgateway/configs/prometheus.yml.tmpl
+++ b/vmgateway/configs/prometheus.yml.tmpl
@@ -5,3 +5,5 @@ scrape_configs:
   - job_name: victoriametrics
     static_configs:
       - targets: ['localhost:8428']
+scrape_config_files:
+- scrape/*.yml


### PR DESCRIPTION
This PR allows external sidecar services to add scrape targets by creating a docker config inside of ./scrape/