### PR TITLE
Add 'Caddy' service

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 monitoring/metrics in a stack
 
 ## Prerequisites
-A pre-existing docker swarm already setup and configured is necessary for orchestration of the stack.
+* A pre-existing docker swarm already setup and configured is necessary for orchestration of the stack.
+* A domain or subdomain with the A record pointed to the IP address of the gateway node for automatic issuance of a Let's Encrypt SSL certificate.
 
 ## Introduction
 
@@ -21,9 +22,10 @@ The mias stack leverages single node, non-replicated, containers of the followin
 * [node-exporter](https://hub.docker.com/r/prom/node-exporter) courtesy of Prometheus
 * [vmagent](https://hub.docker.com/r/victoriametrics/vmagent) courtesy of VictoriaMetrics
 * [vmgateway](https://hub.docker.com/r/victoriametrics/victoria-metrics/) "victoria-metrics-prod" courtesy of VictoriaMetrics
+* [caddy](https://hub.docker.com/_/caddy) "Caddy" courtesy of the Caddy Docker Maintainers
 
 ## Exposed ports
-No additional external ports are opened beyond port `3000` of the Grafana container hosting the vmgateway service.
+No additional external ports are opened beyond ports `443` and `80` of the Grafana container hosting the vmgateway service.
 
 # Installation
 
@@ -50,11 +52,11 @@ Set a unique Grafana dashboard password in the following file:
 
 Deploy the stack to all docker worker nodes.  From the manager node type:
 ```
-docker stack deploy -c docker-compose.yml monitoring
+MIAS_DOMAIN="your-specified-domain.com" docker stack deploy -c docker-compose.yml monitoring
 ```
 
 ## Post installation
-Visit port `3000` of the labeled gateway node and use the username `admin` with the previously specified password.
+Visit port `https://your-specified-domain.com` use the username `admin` with the previously specified password.
 
 ## Tagging images
 You may desire to tag the images within `docker-compose.yml` instead of relying upon the latest images for a more consistent deployment experience in production.
@@ -66,6 +68,7 @@ docker service logs monitoring_grafana -f
 docker service logs monitoring_node-exporter -f
 docker service logs monitoring_vmagent -f
 docker service logs monitoring_vmgateway -f
+docker service logs monitoring_caddy -f
 ```
 
 ## Credits

--- a/caddy/configs/Caddyfile.tmpl
+++ b/caddy/configs/Caddyfile.tmpl
@@ -1,0 +1,16 @@
+# The Caddyfile is an easy way to configure your Caddy web server.
+#
+# Unless the file starts with a global options block, the first
+# uncommented line is always the address of your site.
+#
+# To use your own domain name (with automatic HTTPS), first make
+# sure your domain's A/AAAA DNS records are properly pointed to
+# this machine's public IP, then replace ":80" below with your
+# domain name.
+
+{{ env "MIAS_DOMAIN" }} {
+	reverse_proxy http://grafana:3000
+}
+
+# Refer to the Caddy docs for more information:
+# https://caddyserver.com/docs/caddyfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ volumes:
   vmagent_data:
   vmgateway_data:
   grafana-storage:
+  caddy_data:
+    external: true
+  caddy_config:
 
 services:
   # The services listed below are a part of the monitoring gateway
@@ -26,10 +29,10 @@ services:
     environment:
       GF_SECURITY_ADMIN_PASSWORD__FILE: "/run/secrets/gf_admin_password"
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: "/etc/grafana/provisioning/dashboards.d/home.json"
+      GF_SERVER_DOMAIN: "${MAIS_DOMAIN}"
+      GF_SERVER_ROOT_URL: "https://${MIAS_DOMAIN}"
     secrets:
       - gf_admin_password
-    ports:
-      - "3000:3000"
     configs:
       - source: gfautomaticdashboard
         target: /etc/grafana/provisioning/dashboards/automatic.yml
@@ -74,7 +77,33 @@ services:
       resources:
         limits:
           memory: 512M
-    
+  # caddyserver is a reverse proxy featuring automatic letsencrypt certificates.  It is used to expose the Grafana dashboard to the Internet.
+  caddy:
+    image: caddy:latest
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - monitoring
+    environment:
+      MIAS_DOMAIN: ${MIAS_DOMAIN}
+    configs:
+      - source: caddy
+        target: /etc/caddy/Caddyfile
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.monitoringrole == gateway
+        max_replicas_per_node: 1
+      resources:
+        limits:
+          memory: 512M
+
   # The services listed below are part of the monitoring agent
   #
   # node-exporter collects local system metrics on the docker node and exposes them via local http server
@@ -138,6 +167,10 @@ configs:
     external: false
   gfdatasource:
     file: ./vmgateway/configs/provisioning/datasources/automatic.yml
+    external: false
+  caddy:
+    template_driver: golang
+    file: ./caddy/configs/Caddyfile.tmpl
     external: false
 
 secrets:


### PR DESCRIPTION
Add Caddy as a reverse proxy for Grafana so that a Let's Encrypt certificate for the dashboard can be automatically provisioned and kept updated.