### PR TITLE
Use a multiservice image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
         target: /etc/grafana/provisioning/dashboards.d/home.json
       - source: gfdatasource
         target: /etc/grafana/provisioning/datasources/automatic.yml
+    depends_on:
+      - caddy
     deploy:
       mode: replicated
       replicas: 1
@@ -106,45 +108,24 @@ services:
 
   # The services listed below are part of the monitoring agent
   #
-  # node-exporter collects local system metrics on the docker node and exposes them via local http server
-  node-exporter:
-    image: prom/node-exporter:latest
+  # vmagent is a bundled multi-service image that scrapes metrics exported from node-exporter and then pushes them to the remote victory-metrics gateway node
+  vmagent:
+    image: keith/mais-agent:latest
     volumes:
+      - vmagent_data:/opt/vmagent/storage
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /:/rootfs:ro
-    command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
-    networks:
-      - monitoring
-    deploy:
-      mode: global
-      resources:
-        limits:
-          memory: 512M
-
-  # vmagent scrapes metrics exported from node-exporter and then pushes them to the remote victory-metrics gateway node
-  vmagent:
-    image: victoriametrics/vmagent:latest
-    volumes:
-      - vmagent_data:/opt/vmagent/storage
     environment:
       # We replace the "job" value to the friendlier node hostname so that it appears as such in the Grafana dashboard
       VMAGENT_JOB: "{{.Node.Hostname}}"
-    command:
-      - '-promscrape.config=./prometheus.yml'
-      - '-remoteWrite.tmpDataPath=/opt/vmagent/storage'
-      - '-remoteWrite.url=http://vmgateway:8428/api/v1/write'
     depends_on:
-      - node-exporter
+      - vmgateway
     networks:
       - monitoring
     configs:
       - source: vmagent
-        target: /prometheus.yml
+        target: /project/prometheus.yml
     deploy:
       mode: global
       resources:

--- a/vmagent/.dockerignore
+++ b/vmagent/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+.dockerignore
+configs

--- a/vmagent/Dockerfile
+++ b/vmagent/Dockerfile
@@ -1,0 +1,12 @@
+FROM prom/node-exporter:v1.3.1
+USER root
+WORKDIR /project
+RUN cp /bin/node_exporter /project/node_exporter
+COPY . .
+
+FROM victoriametrics/vmagent:v1.72.0
+WORKDIR /project
+COPY --from=0 /project/node_exporter .
+RUN cp /vmagent-prod /project/vmagent-prod
+COPY . .
+ENTRYPOINT /bin/sh /project/wrapper.sh

--- a/vmagent/configs/prometheus.yml.tmpl
+++ b/vmagent/configs/prometheus.yml.tmpl
@@ -4,6 +4,6 @@ global:
 scrape_configs:
   - job_name: {{ env "VMAGENT_JOB" }}
     static_configs:
-      - targets: ['node-exporter:9100']
+      - targets: ['127.0.0.1:9100']
 scrape_config_files:
 - scrape/*.yml

--- a/vmagent/wrapper.sh
+++ b/vmagent/wrapper.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+cmd1="/project/node_exporter --web.listen-address=0.0.0.0:9100 --path.procfs=/host/proc --path.rootfs=/rootfs --path.sysfs=/host/sys --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
+cmd2="/project/vmagent-prod -promscrape.config=./prometheus.yml -remoteWrite.tmpDataPath=/opt/vmagent/storage -remoteWrite.url=http://vmgateway:8428/api/v1/write"
+
+$cmd1 &
+# Start the second process
+
+$cmd2 &
+# Wait for any process to exit
+wait -n
+
+# Exit with status of process that exited first
+exit $?


### PR DESCRIPTION
Use a multiservice image that bundles node_exporter and vmagent so that the correct metrics are being sent to the vmgateway